### PR TITLE
Replace log with logrus

### DIFF
--- a/telefonicaopencloud/auth_helpers.go
+++ b/telefonicaopencloud/auth_helpers.go
@@ -1,7 +1,7 @@
 package telefonicaopencloud
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"time"
 

--- a/telefonicaopencloud/build_param_util.go
+++ b/telefonicaopencloud/build_param_util.go
@@ -3,7 +3,7 @@ package telefonicaopencloud
 import (
 	"encoding/json"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"reflect"
 	"regexp"
 	"strings"

--- a/telefonicaopencloud/compute_bms_v2_server_addresses.go
+++ b/telefonicaopencloud/compute_bms_v2_server_addresses.go
@@ -11,7 +11,7 @@ package telefonicaopencloud
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/huaweicloud/golangsdk/openstack/compute/v2/servers"

--- a/telefonicaopencloud/compute_instance_v2_networking.go
+++ b/telefonicaopencloud/compute_instance_v2_networking.go
@@ -11,7 +11,7 @@ package telefonicaopencloud
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 
 	"github.com/hashicorp/terraform/helper/schema"

--- a/telefonicaopencloud/config.go
+++ b/telefonicaopencloud/config.go
@@ -4,7 +4,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/http"
 	"os"
 	"strings"

--- a/telefonicaopencloud/data_source_telefonicaopencloud_csbs_backup_policy_v1.go
+++ b/telefonicaopencloud/data_source_telefonicaopencloud_csbs_backup_policy_v1.go
@@ -2,7 +2,7 @@ package telefonicaopencloud
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/huaweicloud/golangsdk/openstack/csbs/v1/policies"

--- a/telefonicaopencloud/data_source_telefonicaopencloud_csbs_backup_v1.go
+++ b/telefonicaopencloud/data_source_telefonicaopencloud_csbs_backup_v1.go
@@ -2,7 +2,7 @@ package telefonicaopencloud
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/huaweicloud/golangsdk/openstack/csbs/v1/backup"

--- a/telefonicaopencloud/data_source_telefonicaopencloud_cts_tracker_v1.go
+++ b/telefonicaopencloud/data_source_telefonicaopencloud_cts_tracker_v1.go
@@ -2,7 +2,7 @@ package telefonicaopencloud
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/huaweicloud/golangsdk/openstack/cts/v1/tracker"

--- a/telefonicaopencloud/data_source_telefonicaopencloud_dcs_az_v1.go
+++ b/telefonicaopencloud/data_source_telefonicaopencloud_dcs_az_v1.go
@@ -2,7 +2,7 @@ package telefonicaopencloud
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/huaweicloud/golangsdk/openstack/dcs/v1/availablezones"

--- a/telefonicaopencloud/data_source_telefonicaopencloud_dcs_maintainwindow_v1.go
+++ b/telefonicaopencloud/data_source_telefonicaopencloud_dcs_maintainwindow_v1.go
@@ -2,7 +2,7 @@ package telefonicaopencloud
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strconv"
 
 	"github.com/hashicorp/terraform/helper/schema"

--- a/telefonicaopencloud/data_source_telefonicaopencloud_dcs_product_v1.go
+++ b/telefonicaopencloud/data_source_telefonicaopencloud_dcs_product_v1.go
@@ -2,7 +2,7 @@ package telefonicaopencloud
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/huaweicloud/golangsdk/openstack/dcs/v1/products"

--- a/telefonicaopencloud/data_source_telefonicaopencloud_dns_zone_v2.go
+++ b/telefonicaopencloud/data_source_telefonicaopencloud_dns_zone_v2.go
@@ -2,7 +2,7 @@ package telefonicaopencloud
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform/helper/schema"

--- a/telefonicaopencloud/data_source_telefonicaopencloud_networking_network_v2.go
+++ b/telefonicaopencloud/data_source_telefonicaopencloud_networking_network_v2.go
@@ -2,7 +2,7 @@ package telefonicaopencloud
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strconv"
 
 	"github.com/hashicorp/terraform/helper/schema"

--- a/telefonicaopencloud/data_source_telefonicaopencloud_networking_secgroup_v2.go
+++ b/telefonicaopencloud/data_source_telefonicaopencloud_networking_secgroup_v2.go
@@ -2,7 +2,7 @@ package telefonicaopencloud
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/security/groups"
 

--- a/telefonicaopencloud/data_source_telefonicaopencloud_networking_subnet_v2.go
+++ b/telefonicaopencloud/data_source_telefonicaopencloud_networking_subnet_v2.go
@@ -2,7 +2,7 @@ package telefonicaopencloud
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform/helper/schema"
 

--- a/telefonicaopencloud/data_source_telefonicaopencloud_rds_flavors_v1.go
+++ b/telefonicaopencloud/data_source_telefonicaopencloud_rds_flavors_v1.go
@@ -2,7 +2,7 @@ package telefonicaopencloud
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform/helper/schema"
 

--- a/telefonicaopencloud/data_source_telefonicaopencloud_rts_software_config_v1.go
+++ b/telefonicaopencloud/data_source_telefonicaopencloud_rts_software_config_v1.go
@@ -2,7 +2,7 @@ package telefonicaopencloud
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/huaweicloud/golangsdk/openstack/rts/v1/softwareconfig"

--- a/telefonicaopencloud/data_source_telefonicaopencloud_rts_stack_v1.go
+++ b/telefonicaopencloud/data_source_telefonicaopencloud_rts_stack_v1.go
@@ -2,7 +2,7 @@ package telefonicaopencloud
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/schema"

--- a/telefonicaopencloud/data_source_telefonicaopencloud_s3_bucket_object.go
+++ b/telefonicaopencloud/data_source_telefonicaopencloud_s3_bucket_object.go
@@ -3,7 +3,7 @@ package telefonicaopencloud
 import (
 	"bytes"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"regexp"
 	"strings"
 	"time"

--- a/telefonicaopencloud/data_source_telefonicaopencloud_sfs_file_sysytem_v2.go
+++ b/telefonicaopencloud/data_source_telefonicaopencloud_sfs_file_sysytem_v2.go
@@ -2,7 +2,7 @@ package telefonicaopencloud
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/huaweicloud/golangsdk/openstack/sfs/v2/shares"
 

--- a/telefonicaopencloud/data_source_telefonicaopencloud_vbs_backup_policy_v2.go
+++ b/telefonicaopencloud/data_source_telefonicaopencloud_vbs_backup_policy_v2.go
@@ -2,7 +2,7 @@ package telefonicaopencloud
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/huaweicloud/golangsdk/openstack/vbs/v2/policies"

--- a/telefonicaopencloud/data_source_telefonicaopencloud_vbs_backup_v2.go
+++ b/telefonicaopencloud/data_source_telefonicaopencloud_vbs_backup_v2.go
@@ -2,7 +2,7 @@ package telefonicaopencloud
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/huaweicloud/golangsdk/openstack/vbs/v2/backups"

--- a/telefonicaopencloud/data_source_telefonicaopencloud_vpc_subnet_v1.go
+++ b/telefonicaopencloud/data_source_telefonicaopencloud_vpc_subnet_v1.go
@@ -2,7 +2,7 @@ package telefonicaopencloud
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/huaweicloud/golangsdk/openstack/networking/v1/subnets"
 

--- a/telefonicaopencloud/data_source_telefonicaopencloud_vpc_v1.go
+++ b/telefonicaopencloud/data_source_telefonicaopencloud_vpc_v1.go
@@ -2,7 +2,7 @@ package telefonicaopencloud
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/huaweicloud/golangsdk/openstack/networking/v1/vpcs"
 

--- a/telefonicaopencloud/elb_utils.go
+++ b/telefonicaopencloud/elb_utils.go
@@ -2,7 +2,7 @@ package telefonicaopencloud
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform/helper/resource"

--- a/telefonicaopencloud/lb_v2_shared.go
+++ b/telefonicaopencloud/lb_v2_shared.go
@@ -2,7 +2,7 @@ package telefonicaopencloud
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform/helper/resource"

--- a/telefonicaopencloud/resource_telefonicaopencloud_antiddos_v1.go
+++ b/telefonicaopencloud/resource_telefonicaopencloud_antiddos_v1.go
@@ -2,7 +2,7 @@ package telefonicaopencloud
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform/helper/schema"

--- a/telefonicaopencloud/resource_telefonicaopencloud_as_configuration_v1.go
+++ b/telefonicaopencloud/resource_telefonicaopencloud_as_configuration_v1.go
@@ -4,7 +4,7 @@ import (
 	"crypto/sha1"
 	"encoding/hex"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"regexp"
 
 	"github.com/hashicorp/terraform/helper/schema"

--- a/telefonicaopencloud/resource_telefonicaopencloud_as_configuration_v1_test.go
+++ b/telefonicaopencloud/resource_telefonicaopencloud_as_configuration_v1_test.go
@@ -2,7 +2,7 @@ package telefonicaopencloud
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/resource"

--- a/telefonicaopencloud/resource_telefonicaopencloud_as_group_v1.go
+++ b/telefonicaopencloud/resource_telefonicaopencloud_as_group_v1.go
@@ -2,7 +2,7 @@ package telefonicaopencloud
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"regexp"
 	"strings"
 	"time"

--- a/telefonicaopencloud/resource_telefonicaopencloud_as_group_v1_test.go
+++ b/telefonicaopencloud/resource_telefonicaopencloud_as_group_v1_test.go
@@ -2,7 +2,7 @@ package telefonicaopencloud
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/resource"

--- a/telefonicaopencloud/resource_telefonicaopencloud_as_policy_v1.go
+++ b/telefonicaopencloud/resource_telefonicaopencloud_as_policy_v1.go
@@ -2,7 +2,7 @@ package telefonicaopencloud
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"regexp"
 	"strings"
 	"time"

--- a/telefonicaopencloud/resource_telefonicaopencloud_as_policy_v1_test.go
+++ b/telefonicaopencloud/resource_telefonicaopencloud_as_policy_v1_test.go
@@ -2,7 +2,7 @@ package telefonicaopencloud
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/resource"

--- a/telefonicaopencloud/resource_telefonicaopencloud_blockstorage_volume_v2.go
+++ b/telefonicaopencloud/resource_telefonicaopencloud_blockstorage_volume_v2.go
@@ -3,7 +3,7 @@ package telefonicaopencloud
 import (
 	"bytes"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform/helper/hashcode"

--- a/telefonicaopencloud/resource_telefonicaopencloud_ces_alarmrule.go
+++ b/telefonicaopencloud/resource_telefonicaopencloud_ces_alarmrule.go
@@ -2,7 +2,7 @@ package telefonicaopencloud
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform/helper/resource"

--- a/telefonicaopencloud/resource_telefonicaopencloud_compute_bms_server_v2.go
+++ b/telefonicaopencloud/resource_telefonicaopencloud_compute_bms_server_v2.go
@@ -4,7 +4,7 @@ import (
 	"crypto/sha1"
 	"encoding/hex"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"time"
 

--- a/telefonicaopencloud/resource_telefonicaopencloud_compute_floatingip_associate_v2.go
+++ b/telefonicaopencloud/resource_telefonicaopencloud_compute_floatingip_associate_v2.go
@@ -2,7 +2,7 @@ package telefonicaopencloud
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform/helper/schema"

--- a/telefonicaopencloud/resource_telefonicaopencloud_compute_floatingip_v2.go
+++ b/telefonicaopencloud/resource_telefonicaopencloud_compute_floatingip_v2.go
@@ -2,7 +2,7 @@ package telefonicaopencloud
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"time"
 

--- a/telefonicaopencloud/resource_telefonicaopencloud_compute_instance_v2.go
+++ b/telefonicaopencloud/resource_telefonicaopencloud_compute_instance_v2.go
@@ -5,7 +5,7 @@ import (
 	"crypto/sha1"
 	"encoding/hex"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"time"
 

--- a/telefonicaopencloud/resource_telefonicaopencloud_compute_keypair_v2.go
+++ b/telefonicaopencloud/resource_telefonicaopencloud_compute_keypair_v2.go
@@ -2,7 +2,7 @@ package telefonicaopencloud
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/huaweicloud/golangsdk/openstack/compute/v2/extensions/keypairs"

--- a/telefonicaopencloud/resource_telefonicaopencloud_compute_secgroup_v2.go
+++ b/telefonicaopencloud/resource_telefonicaopencloud_compute_secgroup_v2.go
@@ -3,7 +3,7 @@ package telefonicaopencloud
 import (
 	"bytes"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 	"time"
 

--- a/telefonicaopencloud/resource_telefonicaopencloud_compute_servergroup_v2.go
+++ b/telefonicaopencloud/resource_telefonicaopencloud_compute_servergroup_v2.go
@@ -2,7 +2,7 @@ package telefonicaopencloud
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/huaweicloud/golangsdk/openstack/compute/v2/extensions/servergroups"

--- a/telefonicaopencloud/resource_telefonicaopencloud_compute_volume_attach_v2.go
+++ b/telefonicaopencloud/resource_telefonicaopencloud_compute_volume_attach_v2.go
@@ -2,7 +2,7 @@ package telefonicaopencloud
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 	"time"
 

--- a/telefonicaopencloud/resource_telefonicaopencloud_csbs_backup_policy_v1.go
+++ b/telefonicaopencloud/resource_telefonicaopencloud_csbs_backup_policy_v1.go
@@ -2,7 +2,7 @@ package telefonicaopencloud
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform/helper/resource"

--- a/telefonicaopencloud/resource_telefonicaopencloud_csbs_backup_v1.go
+++ b/telefonicaopencloud/resource_telefonicaopencloud_csbs_backup_v1.go
@@ -2,7 +2,7 @@ package telefonicaopencloud
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform/helper/resource"

--- a/telefonicaopencloud/resource_telefonicaopencloud_cts_tracker_v1.go
+++ b/telefonicaopencloud/resource_telefonicaopencloud_cts_tracker_v1.go
@@ -4,7 +4,7 @@ import (
 	"time"
 
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/huaweicloud/golangsdk"

--- a/telefonicaopencloud/resource_telefonicaopencloud_dcs_instance_v1.go
+++ b/telefonicaopencloud/resource_telefonicaopencloud_dcs_instance_v1.go
@@ -2,7 +2,7 @@ package telefonicaopencloud
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform/helper/resource"

--- a/telefonicaopencloud/resource_telefonicaopencloud_dms_group_v1.go
+++ b/telefonicaopencloud/resource_telefonicaopencloud_dms_group_v1.go
@@ -3,7 +3,7 @@ package telefonicaopencloud
 import (
 	"encoding/json"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/huaweicloud/golangsdk/openstack/dms/v1/groups"

--- a/telefonicaopencloud/resource_telefonicaopencloud_dms_queue_v1.go
+++ b/telefonicaopencloud/resource_telefonicaopencloud_dms_queue_v1.go
@@ -2,7 +2,7 @@ package telefonicaopencloud
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/huaweicloud/golangsdk/openstack/dms/v1/queues"

--- a/telefonicaopencloud/resource_telefonicaopencloud_dns_recordset_v2.go
+++ b/telefonicaopencloud/resource_telefonicaopencloud_dns_recordset_v2.go
@@ -2,7 +2,7 @@ package telefonicaopencloud
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 	"time"
 

--- a/telefonicaopencloud/resource_telefonicaopencloud_dns_zone_v2.go
+++ b/telefonicaopencloud/resource_telefonicaopencloud_dns_zone_v2.go
@@ -2,7 +2,7 @@ package telefonicaopencloud
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/huaweicloud/golangsdk"

--- a/telefonicaopencloud/resource_telefonicaopencloud_elb_backendecs.go
+++ b/telefonicaopencloud/resource_telefonicaopencloud_elb_backendecs.go
@@ -2,7 +2,7 @@ package telefonicaopencloud
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform/helper/resource"

--- a/telefonicaopencloud/resource_telefonicaopencloud_elb_backendecs_test.go
+++ b/telefonicaopencloud/resource_telefonicaopencloud_elb_backendecs_test.go
@@ -2,7 +2,7 @@ package telefonicaopencloud
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/resource"

--- a/telefonicaopencloud/resource_telefonicaopencloud_elb_healthcheck.go
+++ b/telefonicaopencloud/resource_telefonicaopencloud_elb_healthcheck.go
@@ -2,7 +2,7 @@ package telefonicaopencloud
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform/helper/resource"

--- a/telefonicaopencloud/resource_telefonicaopencloud_elb_healthcheck_test.go
+++ b/telefonicaopencloud/resource_telefonicaopencloud_elb_healthcheck_test.go
@@ -2,7 +2,7 @@ package telefonicaopencloud
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/resource"

--- a/telefonicaopencloud/resource_telefonicaopencloud_elb_listener.go
+++ b/telefonicaopencloud/resource_telefonicaopencloud_elb_listener.go
@@ -2,7 +2,7 @@ package telefonicaopencloud
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform/helper/resource"

--- a/telefonicaopencloud/resource_telefonicaopencloud_elb_loadbalancer.go
+++ b/telefonicaopencloud/resource_telefonicaopencloud_elb_loadbalancer.go
@@ -2,7 +2,7 @@ package telefonicaopencloud
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform/helper/resource"

--- a/telefonicaopencloud/resource_telefonicaopencloud_fw_firewall_group_v2.go
+++ b/telefonicaopencloud/resource_telefonicaopencloud_fw_firewall_group_v2.go
@@ -2,7 +2,7 @@ package telefonicaopencloud
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform/helper/resource"

--- a/telefonicaopencloud/resource_telefonicaopencloud_fw_policy_v2.go
+++ b/telefonicaopencloud/resource_telefonicaopencloud_fw_policy_v2.go
@@ -2,7 +2,7 @@ package telefonicaopencloud
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform/helper/resource"

--- a/telefonicaopencloud/resource_telefonicaopencloud_fw_rule_v2.go
+++ b/telefonicaopencloud/resource_telefonicaopencloud_fw_rule_v2.go
@@ -2,7 +2,7 @@ package telefonicaopencloud
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/huaweicloud/golangsdk"

--- a/telefonicaopencloud/resource_telefonicaopencloud_maas_task_v1.go
+++ b/telefonicaopencloud/resource_telefonicaopencloud_maas_task_v1.go
@@ -2,7 +2,7 @@ package telefonicaopencloud
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strconv"
 	"time"
 

--- a/telefonicaopencloud/resource_telefonicaopencloud_mrs_cluster_v1.go
+++ b/telefonicaopencloud/resource_telefonicaopencloud_mrs_cluster_v1.go
@@ -2,7 +2,7 @@ package telefonicaopencloud
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strconv"
 	"time"
 

--- a/telefonicaopencloud/resource_telefonicaopencloud_mrs_job_v1.go
+++ b/telefonicaopencloud/resource_telefonicaopencloud_mrs_job_v1.go
@@ -2,7 +2,7 @@ package telefonicaopencloud
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform/helper/resource"

--- a/telefonicaopencloud/resource_telefonicaopencloud_networking_floatingip_v2.go
+++ b/telefonicaopencloud/resource_telefonicaopencloud_networking_floatingip_v2.go
@@ -2,7 +2,7 @@ package telefonicaopencloud
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform/helper/resource"

--- a/telefonicaopencloud/resource_telefonicaopencloud_networking_network_v2.go
+++ b/telefonicaopencloud/resource_telefonicaopencloud_networking_network_v2.go
@@ -2,7 +2,7 @@ package telefonicaopencloud
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strconv"
 	"time"
 

--- a/telefonicaopencloud/resource_telefonicaopencloud_networking_port_v2.go
+++ b/telefonicaopencloud/resource_telefonicaopencloud_networking_port_v2.go
@@ -3,7 +3,7 @@ package telefonicaopencloud
 import (
 	"bytes"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform/helper/hashcode"

--- a/telefonicaopencloud/resource_telefonicaopencloud_networking_router_interface_v2.go
+++ b/telefonicaopencloud/resource_telefonicaopencloud_networking_router_interface_v2.go
@@ -2,7 +2,7 @@ package telefonicaopencloud
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform/helper/resource"

--- a/telefonicaopencloud/resource_telefonicaopencloud_networking_router_route_v2.go
+++ b/telefonicaopencloud/resource_telefonicaopencloud_networking_router_route_v2.go
@@ -2,7 +2,7 @@ package telefonicaopencloud
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform/helper/schema"

--- a/telefonicaopencloud/resource_telefonicaopencloud_networking_router_v2.go
+++ b/telefonicaopencloud/resource_telefonicaopencloud_networking_router_v2.go
@@ -2,7 +2,7 @@ package telefonicaopencloud
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform/helper/resource"

--- a/telefonicaopencloud/resource_telefonicaopencloud_networking_secgroup_rule_v2.go
+++ b/telefonicaopencloud/resource_telefonicaopencloud_networking_secgroup_rule_v2.go
@@ -2,7 +2,7 @@ package telefonicaopencloud
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strconv"
 	"strings"
 	"time"

--- a/telefonicaopencloud/resource_telefonicaopencloud_networking_secgroup_v2.go
+++ b/telefonicaopencloud/resource_telefonicaopencloud_networking_secgroup_v2.go
@@ -2,7 +2,7 @@ package telefonicaopencloud
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform/helper/resource"

--- a/telefonicaopencloud/resource_telefonicaopencloud_networking_subnet_v2.go
+++ b/telefonicaopencloud/resource_telefonicaopencloud_networking_subnet_v2.go
@@ -2,7 +2,7 @@ package telefonicaopencloud
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform/helper/resource"

--- a/telefonicaopencloud/resource_telefonicaopencloud_rds_instance_v1.go
+++ b/telefonicaopencloud/resource_telefonicaopencloud_rds_instance_v1.go
@@ -2,7 +2,7 @@ package telefonicaopencloud
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"strings"
 	"time"

--- a/telefonicaopencloud/resource_telefonicaopencloud_rts_software_config_v1.go
+++ b/telefonicaopencloud/resource_telefonicaopencloud_rts_software_config_v1.go
@@ -2,7 +2,7 @@ package telefonicaopencloud
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform/helper/schema"

--- a/telefonicaopencloud/resource_telefonicaopencloud_rts_stack_v1.go
+++ b/telefonicaopencloud/resource_telefonicaopencloud_rts_stack_v1.go
@@ -2,7 +2,7 @@ package telefonicaopencloud
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"reflect"

--- a/telefonicaopencloud/resource_telefonicaopencloud_s3_bucket.go
+++ b/telefonicaopencloud/resource_telefonicaopencloud_s3_bucket.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/url"
 	"regexp"
 	"strings"

--- a/telefonicaopencloud/resource_telefonicaopencloud_s3_bucket_object.go
+++ b/telefonicaopencloud/resource_telefonicaopencloud_s3_bucket_object.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"sort"
 	"strings"

--- a/telefonicaopencloud/resource_telefonicaopencloud_s3_bucket_policy.go
+++ b/telefonicaopencloud/resource_telefonicaopencloud_s3_bucket_policy.go
@@ -2,7 +2,7 @@ package telefonicaopencloud
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"

--- a/telefonicaopencloud/resource_telefonicaopencloud_sfs_file_system_v2.go
+++ b/telefonicaopencloud/resource_telefonicaopencloud_sfs_file_system_v2.go
@@ -2,7 +2,7 @@ package telefonicaopencloud
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform/helper/resource"

--- a/telefonicaopencloud/resource_telefonicaopencloud_smn_subscription_v2.go
+++ b/telefonicaopencloud/resource_telefonicaopencloud_smn_subscription_v2.go
@@ -2,7 +2,7 @@ package telefonicaopencloud
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform/helper/schema"
 

--- a/telefonicaopencloud/resource_telefonicaopencloud_smn_topic_v2.go
+++ b/telefonicaopencloud/resource_telefonicaopencloud_smn_topic_v2.go
@@ -2,7 +2,7 @@ package telefonicaopencloud
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform/helper/schema"
 

--- a/telefonicaopencloud/resource_telefonicaopencloud_vbs_backup_policy_v2.go
+++ b/telefonicaopencloud/resource_telefonicaopencloud_vbs_backup_policy_v2.go
@@ -2,7 +2,7 @@ package telefonicaopencloud
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform/helper/schema"

--- a/telefonicaopencloud/resource_telefonicaopencloud_vbs_backup_v2.go
+++ b/telefonicaopencloud/resource_telefonicaopencloud_vbs_backup_v2.go
@@ -2,7 +2,7 @@ package telefonicaopencloud
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform/helper/resource"

--- a/telefonicaopencloud/resource_telefonicaopencloud_vpc_eip_v1.go
+++ b/telefonicaopencloud/resource_telefonicaopencloud_vpc_eip_v1.go
@@ -2,7 +2,7 @@ package telefonicaopencloud
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/huaweicloud/golangsdk"

--- a/telefonicaopencloud/resource_telefonicaopencloud_vpc_peering_connection_accepter_v2.go
+++ b/telefonicaopencloud/resource_telefonicaopencloud_vpc_peering_connection_accepter_v2.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/huaweicloud/golangsdk"
 	"github.com/huaweicloud/golangsdk/openstack/networking/v2/peerings"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 )
 

--- a/telefonicaopencloud/resource_telefonicaopencloud_vpc_peering_connection_v2.go
+++ b/telefonicaopencloud/resource_telefonicaopencloud_vpc_peering_connection_v2.go
@@ -6,7 +6,7 @@ import (
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/huaweicloud/golangsdk"
 	"github.com/huaweicloud/golangsdk/openstack/networking/v2/peerings"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 )
 

--- a/telefonicaopencloud/resource_telefonicaopencloud_vpc_subnet_v1.go
+++ b/telefonicaopencloud/resource_telefonicaopencloud_vpc_subnet_v1.go
@@ -2,7 +2,7 @@ package telefonicaopencloud
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform/helper/schema"

--- a/telefonicaopencloud/resource_telefonicaopencloud_vpc_v1.go
+++ b/telefonicaopencloud/resource_telefonicaopencloud_vpc_v1.go
@@ -2,7 +2,7 @@ package telefonicaopencloud
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform/helper/schema"

--- a/telefonicaopencloud/types.go
+++ b/telefonicaopencloud/types.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/http"
 	"strings"
 

--- a/vendor/github.com/aws/aws-sdk-go/aws/logger.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/logger.go
@@ -1,7 +1,7 @@
 package aws
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 )
 

--- a/vendor/github.com/fsouza/go-dockerclient/external/github.com/Sirupsen/logrus/logrus.go
+++ b/vendor/github.com/fsouza/go-dockerclient/external/github.com/Sirupsen/logrus/logrus.go
@@ -2,7 +2,7 @@ package logrus
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 )
 
 // Fields type, used to pass to `WithFields`.

--- a/vendor/github.com/hashicorp/go-plugin/client.go
+++ b/vendor/github.com/hashicorp/go-plugin/client.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net"
 	"os"
 	"os/exec"

--- a/vendor/github.com/hashicorp/go-plugin/mux_broker.go
+++ b/vendor/github.com/hashicorp/go-plugin/mux_broker.go
@@ -3,7 +3,7 @@ package plugin
 import (
 	"encoding/binary"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net"
 	"sync"
 	"sync/atomic"

--- a/vendor/github.com/hashicorp/go-plugin/rpc_server.go
+++ b/vendor/github.com/hashicorp/go-plugin/rpc_server.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net"
 	"net/rpc"
 	"sync"

--- a/vendor/github.com/hashicorp/go-plugin/server.go
+++ b/vendor/github.com/hashicorp/go-plugin/server.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net"
 	"os"
 	"os/signal"

--- a/vendor/github.com/hashicorp/go-plugin/stream.go
+++ b/vendor/github.com/hashicorp/go-plugin/stream.go
@@ -2,7 +2,7 @@ package plugin
 
 import (
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 )
 
 func copyStream(name string, dst io.Writer, src io.Reader) {

--- a/vendor/github.com/hashicorp/logutils/level.go
+++ b/vendor/github.com/hashicorp/logutils/level.go
@@ -51,7 +51,7 @@ func (f *LevelFilter) Check(line []byte) bool {
 
 func (f *LevelFilter) Write(p []byte) (n int, err error) {
 	// Note in general that io.Writer can receive any byte sequence
-	// to write, but the "log" package always guarantees that we only
+	// to write, but the log "github.com/sourcegraph-ce/logrus" package always guarantees that we only
 	// get a single line. We use that as a slight optimization within
 	// this method, assuming we're dealing with a single, complete line
 	// of log data.

--- a/vendor/github.com/hashicorp/terraform/config/interpolate_funcs.go
+++ b/vendor/github.com/hashicorp/terraform/config/interpolate_funcs.go
@@ -84,7 +84,7 @@ func Funcs() map[string]ast.Function {
 		"jsonencode":   interpolationFuncJSONEncode(),
 		"length":       interpolationFuncLength(),
 		"list":         interpolationFuncList(),
-		"log":          interpolationFuncLog(),
+		log "github.com/sourcegraph-ce/logrus":          interpolationFuncLog(),
 		"lower":        interpolationFuncLower(),
 		"map":          interpolationFuncMap(),
 		"max":          interpolationFuncMax(),

--- a/vendor/github.com/hashicorp/terraform/dag/marshal.go
+++ b/vendor/github.com/hashicorp/terraform/dag/marshal.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"reflect"
 	"sort"
 	"strconv"

--- a/vendor/github.com/hashicorp/terraform/dag/walk.go
+++ b/vendor/github.com/hashicorp/terraform/dag/walk.go
@@ -3,7 +3,7 @@ package dag
 import (
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sync"
 	"time"
 

--- a/vendor/github.com/hashicorp/terraform/helper/logging/logging.go
+++ b/vendor/github.com/hashicorp/terraform/helper/logging/logging.go
@@ -3,7 +3,7 @@ package logging
 import (
 	"io"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"strings"
 	"syscall"

--- a/vendor/github.com/hashicorp/terraform/helper/logging/transport.go
+++ b/vendor/github.com/hashicorp/terraform/helper/logging/transport.go
@@ -1,7 +1,7 @@
 package logging
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/http"
 	"net/http/httputil"
 )

--- a/vendor/github.com/hashicorp/terraform/helper/mutexkv/mutexkv.go
+++ b/vendor/github.com/hashicorp/terraform/helper/mutexkv/mutexkv.go
@@ -1,7 +1,7 @@
 package mutexkv
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sync"
 )
 

--- a/vendor/github.com/hashicorp/terraform/helper/resource/state.go
+++ b/vendor/github.com/hashicorp/terraform/helper/resource/state.go
@@ -1,7 +1,7 @@
 package resource
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 )
 

--- a/vendor/github.com/hashicorp/terraform/helper/resource/testing.go
+++ b/vendor/github.com/hashicorp/terraform/helper/resource/testing.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"path/filepath"
 	"reflect"

--- a/vendor/github.com/hashicorp/terraform/helper/resource/testing_config.go
+++ b/vendor/github.com/hashicorp/terraform/helper/resource/testing_config.go
@@ -2,7 +2,7 @@ package resource
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform/terraform"

--- a/vendor/github.com/hashicorp/terraform/helper/resource/testing_import_state.go
+++ b/vendor/github.com/hashicorp/terraform/helper/resource/testing_import_state.go
@@ -2,7 +2,7 @@ package resource
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"reflect"
 	"strings"
 

--- a/vendor/github.com/hashicorp/terraform/helper/schema/resource.go
+++ b/vendor/github.com/hashicorp/terraform/helper/schema/resource.go
@@ -3,7 +3,7 @@ package schema
 import (
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strconv"
 
 	"github.com/hashicorp/terraform/config"

--- a/vendor/github.com/hashicorp/terraform/helper/schema/resource_data.go
+++ b/vendor/github.com/hashicorp/terraform/helper/schema/resource_data.go
@@ -1,7 +1,7 @@
 package schema
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"reflect"
 	"strings"
 	"sync"

--- a/vendor/github.com/hashicorp/terraform/helper/schema/resource_timeout.go
+++ b/vendor/github.com/hashicorp/terraform/helper/schema/resource_timeout.go
@@ -2,7 +2,7 @@ package schema
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform/terraform"

--- a/vendor/github.com/hashicorp/terraform/plugin/discovery/find.go
+++ b/vendor/github.com/hashicorp/terraform/plugin/discovery/find.go
@@ -2,7 +2,7 @@ package discovery
 
 import (
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"path/filepath"
 	"strings"
 )

--- a/vendor/github.com/hashicorp/terraform/plugin/discovery/get.go
+++ b/vendor/github.com/hashicorp/terraform/plugin/discovery/get.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/http"
 	"os"
 	"runtime"

--- a/vendor/github.com/hashicorp/terraform/plugin/discovery/signature.go
+++ b/vendor/github.com/hashicorp/terraform/plugin/discovery/signature.go
@@ -2,7 +2,7 @@ package discovery
 
 import (
 	"bytes"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"golang.org/x/crypto/openpgp"

--- a/vendor/github.com/hashicorp/terraform/terraform/context.go
+++ b/vendor/github.com/hashicorp/terraform/terraform/context.go
@@ -3,7 +3,7 @@ package terraform
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sort"
 	"strings"
 	"sync"

--- a/vendor/github.com/hashicorp/terraform/terraform/eval.go
+++ b/vendor/github.com/hashicorp/terraform/terraform/eval.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 )
 

--- a/vendor/github.com/hashicorp/terraform/terraform/eval_apply.go
+++ b/vendor/github.com/hashicorp/terraform/terraform/eval_apply.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strconv"
 
 	"github.com/hashicorp/go-multierror"

--- a/vendor/github.com/hashicorp/terraform/terraform/eval_context_builtin.go
+++ b/vendor/github.com/hashicorp/terraform/terraform/eval_context_builtin.go
@@ -3,7 +3,7 @@ package terraform
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 	"sync"
 

--- a/vendor/github.com/hashicorp/terraform/terraform/eval_count_boundary.go
+++ b/vendor/github.com/hashicorp/terraform/terraform/eval_count_boundary.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 )
 
 // EvalCountFixZeroOneBoundaryGlobal is an EvalNode that fixes up the state

--- a/vendor/github.com/hashicorp/terraform/terraform/eval_diff.go
+++ b/vendor/github.com/hashicorp/terraform/terraform/eval_diff.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform/config"

--- a/vendor/github.com/hashicorp/terraform/terraform/eval_output.go
+++ b/vendor/github.com/hashicorp/terraform/terraform/eval_output.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform/config"
 )

--- a/vendor/github.com/hashicorp/terraform/terraform/eval_refresh.go
+++ b/vendor/github.com/hashicorp/terraform/terraform/eval_refresh.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 )
 
 // EvalRefresh is an EvalNode implementation that does a refresh for

--- a/vendor/github.com/hashicorp/terraform/terraform/eval_variable.go
+++ b/vendor/github.com/hashicorp/terraform/terraform/eval_variable.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"reflect"
 	"strconv"
 	"strings"

--- a/vendor/github.com/hashicorp/terraform/terraform/graph.go
+++ b/vendor/github.com/hashicorp/terraform/terraform/graph.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"runtime/debug"
 	"strings"
 

--- a/vendor/github.com/hashicorp/terraform/terraform/graph_builder.go
+++ b/vendor/github.com/hashicorp/terraform/terraform/graph_builder.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 )
 

--- a/vendor/github.com/hashicorp/terraform/terraform/graph_builder_refresh.go
+++ b/vendor/github.com/hashicorp/terraform/terraform/graph_builder_refresh.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform/config"
 	"github.com/hashicorp/terraform/config/module"

--- a/vendor/github.com/hashicorp/terraform/terraform/graph_walk_context.go
+++ b/vendor/github.com/hashicorp/terraform/terraform/graph_walk_context.go
@@ -3,7 +3,7 @@ package terraform
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sync"
 
 	"github.com/hashicorp/errwrap"

--- a/vendor/github.com/hashicorp/terraform/terraform/interpolate.go
+++ b/vendor/github.com/hashicorp/terraform/terraform/interpolate.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 	"strconv"
 	"strings"

--- a/vendor/github.com/hashicorp/terraform/terraform/plan.go
+++ b/vendor/github.com/hashicorp/terraform/terraform/plan.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sync"
 
 	"github.com/hashicorp/terraform/config/module"

--- a/vendor/github.com/hashicorp/terraform/terraform/shadow_resource_provider.go
+++ b/vendor/github.com/hashicorp/terraform/terraform/shadow_resource_provider.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sync"
 
 	"github.com/hashicorp/go-multierror"

--- a/vendor/github.com/hashicorp/terraform/terraform/shadow_resource_provisioner.go
+++ b/vendor/github.com/hashicorp/terraform/terraform/shadow_resource_provisioner.go
@@ -3,7 +3,7 @@ package terraform
 import (
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sync"
 
 	"github.com/hashicorp/go-multierror"

--- a/vendor/github.com/hashicorp/terraform/terraform/state.go
+++ b/vendor/github.com/hashicorp/terraform/terraform/state.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"reflect"
 	"sort"
 	"strconv"

--- a/vendor/github.com/hashicorp/terraform/terraform/state_upgrade_v2_to_v3.go
+++ b/vendor/github.com/hashicorp/terraform/terraform/state_upgrade_v2_to_v3.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"regexp"
 	"sort"
 	"strconv"

--- a/vendor/github.com/hashicorp/terraform/terraform/transform_attach_config_provider.go
+++ b/vendor/github.com/hashicorp/terraform/terraform/transform_attach_config_provider.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform/config"
 	"github.com/hashicorp/terraform/config/module"

--- a/vendor/github.com/hashicorp/terraform/terraform/transform_attach_config_resource.go
+++ b/vendor/github.com/hashicorp/terraform/terraform/transform_attach_config_resource.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform/config"
 	"github.com/hashicorp/terraform/config/module"

--- a/vendor/github.com/hashicorp/terraform/terraform/transform_attach_state.go
+++ b/vendor/github.com/hashicorp/terraform/terraform/transform_attach_state.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform/dag"
 )

--- a/vendor/github.com/hashicorp/terraform/terraform/transform_config.go
+++ b/vendor/github.com/hashicorp/terraform/terraform/transform_config.go
@@ -3,7 +3,7 @@ package terraform
 import (
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sync"
 
 	"github.com/hashicorp/terraform/config"

--- a/vendor/github.com/hashicorp/terraform/terraform/transform_destroy_cbd.go
+++ b/vendor/github.com/hashicorp/terraform/terraform/transform_destroy_cbd.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform/config/module"
 	"github.com/hashicorp/terraform/dag"

--- a/vendor/github.com/hashicorp/terraform/terraform/transform_destroy_edge.go
+++ b/vendor/github.com/hashicorp/terraform/terraform/transform_destroy_edge.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform/config/module"
 	"github.com/hashicorp/terraform/dag"

--- a/vendor/github.com/hashicorp/terraform/terraform/transform_diff.go
+++ b/vendor/github.com/hashicorp/terraform/terraform/transform_diff.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform/config/module"
 	"github.com/hashicorp/terraform/dag"

--- a/vendor/github.com/hashicorp/terraform/terraform/transform_expand.go
+++ b/vendor/github.com/hashicorp/terraform/terraform/transform_expand.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform/dag"
 )

--- a/vendor/github.com/hashicorp/terraform/terraform/transform_module_variable.go
+++ b/vendor/github.com/hashicorp/terraform/terraform/transform_module_variable.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform/config"
 	"github.com/hashicorp/terraform/config/module"

--- a/vendor/github.com/hashicorp/terraform/terraform/transform_orphan_count.go
+++ b/vendor/github.com/hashicorp/terraform/terraform/transform_orphan_count.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform/dag"
 )

--- a/vendor/github.com/hashicorp/terraform/terraform/transform_orphan_output.go
+++ b/vendor/github.com/hashicorp/terraform/terraform/transform_orphan_output.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform/config"
 	"github.com/hashicorp/terraform/config/module"

--- a/vendor/github.com/hashicorp/terraform/terraform/transform_provider.go
+++ b/vendor/github.com/hashicorp/terraform/terraform/transform_provider.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/go-multierror"

--- a/vendor/github.com/hashicorp/terraform/terraform/transform_reference.go
+++ b/vendor/github.com/hashicorp/terraform/terraform/transform_reference.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform/config"

--- a/vendor/github.com/hashicorp/terraform/terraform/transform_state.go
+++ b/vendor/github.com/hashicorp/terraform/terraform/transform_state.go
@@ -2,7 +2,7 @@ package terraform
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform/dag"
 )

--- a/vendor/github.com/hashicorp/terraform/terraform/transform_targets.go
+++ b/vendor/github.com/hashicorp/terraform/terraform/transform_targets.go
@@ -1,7 +1,7 @@
 package terraform
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform/dag"
 )

--- a/vendor/github.com/hashicorp/yamux/session.go
+++ b/vendor/github.com/hashicorp/yamux/session.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"math"
 	"net"
 	"strings"

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/autoscaling/v1/configurations/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/autoscaling/v1/configurations/requests.go
@@ -2,7 +2,7 @@ package configurations
 
 import (
 	"encoding/base64"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/huaweicloud/golangsdk"
 	"github.com/huaweicloud/golangsdk/pagination"

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/autoscaling/v1/groups/urls.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/autoscaling/v1/groups/urls.go
@@ -1,7 +1,7 @@
 package groups
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/huaweicloud/golangsdk"
 )

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/cloudeyeservice/alarmrule/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/cloudeyeservice/alarmrule/requests.go
@@ -1,7 +1,7 @@
 package alarmrule
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/huaweicloud/golangsdk"
 )

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/mrs/v1/cluster/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/mrs/v1/cluster/requests.go
@@ -1,7 +1,7 @@
 package cluster
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/huaweicloud/golangsdk"
 )

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/mrs/v1/job/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/mrs/v1/job/requests.go
@@ -1,7 +1,7 @@
 package job
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/huaweicloud/golangsdk"
 )

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/elb/backendecs/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/elb/backendecs/requests.go
@@ -1,7 +1,7 @@
 package backendecs
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/huaweicloud/golangsdk"
 	"github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/elb"

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/elb/healthcheck/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/elb/healthcheck/requests.go
@@ -1,7 +1,7 @@
 package healthcheck
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/huaweicloud/golangsdk"
 )

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/elb/listeners/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/elb/listeners/requests.go
@@ -1,7 +1,7 @@
 package listeners
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/huaweicloud/golangsdk"
 	"github.com/huaweicloud/golangsdk/openstack/utils"

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/elb/loadbalancers/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/elb/loadbalancers/requests.go
@@ -1,7 +1,7 @@
 package loadbalancers
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/huaweicloud/golangsdk"
 	"github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/elb"

--- a/vendor/github.com/huaweicloud/golangsdk/signer_helper.go
+++ b/vendor/github.com/huaweicloud/golangsdk/signer_helper.go
@@ -8,7 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/http"
 	"net/textproto"
 	"net/url"

--- a/vendor/golang.org/x/crypto/ssh/channel.go
+++ b/vendor/golang.org/x/crypto/ssh/channel.go
@@ -9,7 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sync"
 )
 

--- a/vendor/golang.org/x/crypto/ssh/handshake.go
+++ b/vendor/golang.org/x/crypto/ssh/handshake.go
@@ -9,7 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net"
 	"sync"
 )

--- a/vendor/golang.org/x/crypto/ssh/mux.go
+++ b/vendor/golang.org/x/crypto/ssh/mux.go
@@ -8,7 +8,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sync"
 	"sync/atomic"
 )

--- a/vendor/golang.org/x/crypto/ssh/transport.go
+++ b/vendor/golang.org/x/crypto/ssh/transport.go
@@ -8,7 +8,7 @@ import (
 	"bufio"
 	"errors"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 )
 
 // debugTransport if set, will print packet types as they go over the


### PR DESCRIPTION
stdout: Namespace(repository='github.com/sourcegraph-ce/terraform-provider-telefonicaopencloud', batch_change_name='log-provider-go-with-python-script-2', description='This batch change opens a PR for each .go file in a terraform provider repository, and replaces the standard library "log" import statement with the "logrus" library.  This batch change for each repository where the import "log" statement is replaced with "logrus".\n', secret='supersecret', reopen=False)
examples
scripts
.github
vendor
website
.git
telefonicaopencloud
autoscaling-with-alarm
app-with-networking
csbs-backup-with-ecs
vbs-backup-with-volume
gopkg.in
golang.org
github.com
yaml.v2
x
crypto
net
cast5
ssh
openpgp
curve25519
blowfish
bcrypt
ed25519
s2k
armor
packet
elgamal
errors
internal
edwards25519
html
atom
jen20
rancher
huaweicloud
go-ini
apparentlymart
satori
jmespath
Unknwon
hashicorp
fsouza
blang
mitchellh
davecgh
aws
bgentry
awspolicyequivalence
go-rancher
golangsdk
openstack
internal
pagination
dms
utils
networking
identity
smn
mrs
rts
csbs
objectstorage
sfs
cts
blockstorage
autoscaling
vbs
antiddos
maas
dns
dcs
cloudeyeservice
compute
bms
rds
v1
groups
queues
v1
v2
vpcs
bandwidths
subnets
eips
peerings
ports
extensions
networks
subnets
provider
security
fwaas_v2
elb
lbaas_v2
layer3
groups
rules
policies
firewall_groups
rules
routerinsertion
healthcheck
listeners
loadbalancers
backendecs
monitors
listeners
loadbalancers
pools
floatingips
routers
v3
v2
tokens
endpoints
services
projects
tenants
tokens
v2
subscriptions
topics
v1
cluster
job
v1
stackresources
stacks
softwareconfig
stacktemplates
v1
policies
backup
v1
swauth
v2
shares
v1
tracker
v2
volumes
v1
groups
policies
configurations
instances
v2
policies
backups
v1
antiddos
v1
task
v2
recordsets
zones
v1
maintainwindows
instances
products
availablezones
alarmrule
v2
extensions
images
servers
flavors
availabilityzones
floatingips
volumeattach
startstop
servergroups
schedulerhints
tenantnetworks
secgroups
bootfromvolume
keypairs
v2
tags
servers
v1
instances
flavors
datastores
ini
go-cidr
go-rundeck-api
cidr
go.uuid
go-jmespath
com
go-plugin
go-getter
yamux
errwrap
go-uuid
go-version
go-multierror
go-cleanhttp
hil
terraform
hcl
logutils
helper
url
scanner
ast
parser
dag
moduledeps
plugin
config
flatmap
terraform
helper
discovery
module
mutexkv
experiment
schema
config
shadow
hashcode
resource
logging
hilmapstructure
pathorcontents
acctest
json
hcl
token
scanner
parser
token
scanner
ast
strconv
parser
go-dockerclient
travis-scripts
external
testing
golang.org
github.com
x
net
sys
context
unix
docker
opencontainers
hashicorp
Sirupsen
gorilla
go-units
docker
opts
pkg
idtools
archive
promise
fileutils
ioutils
stdcopy
homedir
system
longpath
pools
runc
libcontainer
user
go-cleanhttp
logrus
context
mux
data
semver
go-homedir
reflectwalk
copystructure
mapstructure
hashstructure
go-spew
spew
aws-sdk-go
service
internal
private
aws
sts
s3
shareddefaults
protocol
rest
restxml
query
xml
queryutil
xmlutil
ec2metadata
signer
defaults
session
endpoints
request
awserr
corehandlers
awsutil
credentials
client
v4
endpointcreds
ec2rolecreds
stscreds
metadata
go-netrc
netrc
docs
r
d
objects
info
branches
logs
refs
hooks
97
1b
31
08
94
8d
65
20
99
9f
24
4e
eb
6e
18
b6
e2
78
e6
66
b0
49
fe
01
bd
57
89
5a
c5
1e
e4
f5
d0
1c
44
95
72
dc
12
b7
ee
11
c8
22
1f
53
7a
47
5c
7c
07
fa
59
87
81
9e
75
52
8e
d6
96
ba
e3
29
02
f2
ac
3f
71
4a
ec
10
0e
e7
69
42
a9
9c
a3
6c
db
ea
ff
bf
dd
76
43
3e
34
60
1d
c9
4c
05
ca
26
06
a4
21
d2
85
19
fd
82
9b
a0
c2
f3
fb
b8
b4
cb
0b
c1
a6
0f
74
93
61
5b
51
cf
d1
c7
de
2a
f6
e9
pack
f7
ef
9a
8b
e8
da
d7
b3
ce
79
3a
b5
f1
ae
e0
be
28
a2
info
f8
80
e5
ed
a7
3c
9d
1a
15
a5
56
7d
c6
2b
fc
ad
09
2e
d4
4b
50
98
73
6d
27
f0
3b
70
7e
bc
7f
46
88
0c
c0
af
d5
a8
5e
35
16
b1
40
67
aa
ab
8c
3d
41
e1
b9
6b
23
84
00
37
83
4f
d3
54
0d
33
2f
8f
d9
39
36
55
63
17
77
c4
92
68
f9
c3
04
38
2c
8a
64
b2
7b
48
32
cd
91
6a
14
5d
bb
2d
cc
5f
58
45
f4
03
a1
25
6f
86
62
df
4d
0a
13
30
90
d8
refs
heads
tags
heads

[_Created by Sourcegraph batch change `admin/log-provider-go-with-python-script-2`._](https://gcp.s0urcegraph.com/users/admin/batch-changes/log-provider-go-with-python-script-2)